### PR TITLE
TPCDS1: Query 70 expressions in order by

### DIFF
--- a/TPC-DS/templates/query-70.sql
+++ b/TPC-DS/templates/query-70.sql
@@ -1,6 +1,8 @@
 SET SCHEMA ##SCHEMA##;
 elapsedtime on;
 -- TPC-DS QUERY 70
+-- replaced the alias lochierarchy with actual expression in the order by
+-- change this back to original once we fix this issue
 
 select top 100 
     sum(ss_net_profit) as total_sum
@@ -33,8 +35,8 @@ select top 100
              )
  group by rollup(s_state,s_county)
  order by
-   lochierarchy desc
-  ,case when lochierarchy = 0 then s_state end
+   grouping(s_state)+grouping(s_county) desc
+  ,case when grouping(s_state)+grouping(s_county) = 0 then s_state end
   ,rank_within_parent
  ;
 


### PR DESCRIPTION
Original query used in alias for a function and the alias was used in the `order by` clause. We currently have a bug for this and the workaround is to expressly specify the function in the order by clause instead of the alias.