### PR TITLE
DB-8083: move all queries to use date intervals

### DIFF
--- a/TPC-DS/templates/query-05.sql
+++ b/TPC-DS/templates/query-05.sql
@@ -18,7 +18,7 @@ with ssr as
      where s_store_sk = ss_store_sk and
            ss_sold_date_sk = d_date_sk
            and d_date between cast('1998-08-04' as date)
-           and (cast('1998-08-18' as date))
+           and (cast('1998-08-04' as date) + 14 )
 
      union all
      select s_store_id,
@@ -31,7 +31,7 @@ with ssr as
      where s_store_sk = sr_store_sk and
            sr_returned_date_sk = d_date_sk
            and d_date between cast('1998-08-04' as date)
-           and (cast('1998-08-18' as date))
+           and (cast('1998-08-04' as date) + 14 )
    ) salesreturns
  group by s_store_id)
   ,
@@ -51,7 +51,7 @@ with ssr as
        from catalog_sales, date_dim, catalog_page
        where cs_sold_date_sk = d_date_sk
              and d_date between cast('1998-08-04' as date)
-             and (cast('1998-08-18' as date))
+             and (cast('1998-08-04' as date) + 14 )
              and cs_catalog_page_sk = cp_catalog_page_sk
        union all
        select cp_catalog_page_id,
@@ -63,7 +63,7 @@ with ssr as
        from catalog_returns, date_dim, catalog_page
        where cr_returned_date_sk = d_date_sk
              and d_date between cast('1998-08-04' as date)
-             and (cast('1998-08-18' as date))
+             and (cast('1998-08-04' as date) + 14 )
              and cp_catalog_page_sk = cr_catalog_page_sk
 
      ) salesreturns
@@ -85,7 +85,7 @@ with ssr as
        from web_sales, date_dim, web_site
        where ws_sold_date_sk = d_date_sk
              and d_date between cast('1998-08-04' as date)
-             and (cast('1998-08-18' as date))
+             and (cast('1998-08-04' as date) + 14 )
              and web_site_sk = ws_web_site_sk
 
        union all
@@ -100,7 +100,7 @@ with ssr as
                                                       and wr_order_number = ws_order_number), date_dim, web_site
        where wr_returned_date_sk = d_date_sk
              and d_date between cast('1998-08-04' as date)
-             and (cast('1998-08-18' as date))
+             and (cast('1998-08-04' as date) + 14 )
              and web_site_sk = ws_web_site_sk
 
      ) salesreturns

--- a/TPC-DS/templates/query-12.sql
+++ b/TPC-DS/templates/query-12.sql
@@ -18,8 +18,7 @@ where
   	and i_category in ('Jewelry', 'Sports', 'Books')
   	and ws_sold_date_sk = d_date_sk
 	and d_date between cast('2001-01-12' as date) 
---				and (cast('2001-01-12' as date) + 30 days)
-			and (cast('2001-02-12' as date))
+			and (cast('2001-01-12' as date) + 30)
 group by 
 	i_item_id
         ,i_item_desc 

--- a/TPC-DS/templates/query-20.sql
+++ b/TPC-DS/templates/query-20.sql
@@ -16,8 +16,7 @@ select top 100 i_item_id
    and i_category in ('Jewelry', 'Sports', 'Books')
    and cs_sold_date_sk = d_date_sk
  and d_date between cast('2001-01-12' as date) 
--- 				and (cast('2001-01-12' as date) + 30 days)
-			and (cast('2001-02-12' as date))
+			and (cast('2001-01-12' as date) + 30)
  group by i_item_id
          ,i_item_desc 
          ,i_category

--- a/TPC-DS/templates/query-21.sql
+++ b/TPC-DS/templates/query-21.sql
@@ -18,10 +18,8 @@ select top 100 *
      and i_item_sk          = inv_item_sk
      and inv_warehouse_sk   = w_warehouse_sk
      and inv_date_sk    = d_date_sk
---     and d_date between (cast ('1998-04-08' as date) - 30 days)
-	and d_date between (cast ('1998-03-08' as date))
---                    and (cast ('1998-04-08' as date) + 30 days)
-			and (cast ('1998-05-08' as date))
+     and d_date between (cast ('1998-04-08' as date) - 30 )
+                    and (cast ('1998-04-08' as date) + 30 )
    group by w_warehouse_name, i_item_id) x
  where (case when inv_before > 0 
              then inv_after / inv_before 

--- a/TPC-DS/templates/query-32.sql
+++ b/TPC-DS/templates/query-32.sql
@@ -10,8 +10,7 @@ where
 i_manufact_id = 269
 and i_item_sk = cs_item_sk 
 and d_date between '1998-03-18' and 
---        (cast('1998-03-18' as date) + 90 days)
-	(cast('1998-06-18' as date))
+        (cast('1998-03-18' as date) + 90 )
 and d_date_sk = cs_sold_date_sk 
 and cs_ext_discount_amt  
      > ( 
@@ -23,8 +22,7 @@ and cs_ext_discount_amt
          where 
               cs_item_sk = i_item_sk 
           and d_date between '1998-03-18' and
---                             (cast('1998-03-18' as date) + 90 days)
-				(cast('1998-06-18' as date))
+                             (cast('1998-03-18' as date) + 90 )
           and d_date_sk = cs_sold_date_sk 
       ) 
 ;

--- a/TPC-DS/templates/query-37.sql
+++ b/TPC-DS/templates/query-37.sql
@@ -8,8 +8,7 @@ select top 100 i_item_id
  where i_current_price between 22 and 22 + 30
  and inv_item_sk = i_item_sk
  and d_date_sk=inv_date_sk
---and d_date between cast('2001-06-02' as date) and (cast('2001-06-02' as date) +  60 days)
- and d_date between cast('2001-06-02' as date) and (cast('2001-08-02' as date))
+ and d_date between cast('2001-06-02' as date) and (cast('2001-06-02' as date) +  60 )
  and i_manufact_id in (678,964,918,849)
  and inv_quantity_on_hand between 100 and 500
  and cs_item_sk = i_item_sk

--- a/TPC-DS/templates/query-40.sql
+++ b/TPC-DS/templates/query-40.sql
@@ -20,8 +20,8 @@ select top 100
  and i_item_sk          = cs_item_sk
  and cs_warehouse_sk    = w_warehouse_sk 
  and cs_sold_date_sk    = d_date_sk
- and d_date between (cast ('1998-03-08' as date))
-                and (cast ('1998-05-08' as date)) 
+ and d_date between (cast ('1998-04-08' as date) - 30)
+                and (cast ('1998-04-08' as date) + 30) 
  group by
     w_state,i_item_id
  order by w_state,i_item_id

--- a/TPC-DS/templates/query-77.sql
+++ b/TPC-DS/templates/query-77.sql
@@ -11,8 +11,7 @@ with ss as
       store
  where ss_sold_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date) 
---                  and (cast('1998-08-04' as date) +  30 days) 
-		and (cast('1998-09-04' as date))
+                and (cast('1998-08-04' as date) + 30 ) 
        and ss_store_sk = s_store_sk
  group by s_store_sk)
  ,
@@ -25,7 +24,7 @@ with ss as
       store
  where sr_returned_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date)
-                  and (cast('1998-09-04' as date))
+                  and (cast('1998-08-04' as date) + 30 )
        and sr_store_sk = s_store_sk
  group by s_store_sk), 
  cs as
@@ -36,7 +35,7 @@ with ss as
       date_dim
  where cs_sold_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date)
-                  and (cast('1998-09-04' as date))
+                  and (cast('1998-08-04' as date) + 30 )
  group by cs_call_center_sk 
  ), 
  cr as
@@ -47,7 +46,7 @@ with ss as
       date_dim
  where cr_returned_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date)
-                  and (cast('1998-09-04' as date))
+                  and (cast('1998-08-04' as date) + 30 )
  group by cr_call_center_sk
  ), 
  ws as
@@ -59,7 +58,7 @@ with ss as
       web_page
  where ws_sold_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date)
-                  and (cast('1998-09-04' as date))
+                  and (cast('1998-08-04' as date) + 30 )
        and ws_web_page_sk = wp_web_page_sk
  group by wp_web_page_sk), 
  wr as
@@ -71,7 +70,7 @@ with ss as
       web_page
  where wr_returned_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date)
-                  and (cast('1998-09-04' as date))
+                  and (cast('1998-08-04' as date) + 30 )
        and wr_web_page_sk = wp_web_page_sk
  group by wp_web_page_sk)
   select top 100 channel

--- a/TPC-DS/templates/query-80.sql
+++ b/TPC-DS/templates/query-80.sql
@@ -14,8 +14,7 @@ with ssr as
      promotion
  where ss_sold_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date) 
---                  and (cast('1998-08-04' as date) +  30 days)
-		and (cast('1998-09-04' as date))
+                and (cast('1998-08-04' as date) +  30 )
        and ss_store_sk = s_store_sk
        and ss_item_sk = i_item_sk
        and i_current_price > 50
@@ -36,7 +35,7 @@ with ssr as
      promotion
  where cs_sold_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date)
-                  and (cast('1998-09-04' as date))
+                  and (cast('1998-08-04' as date) + 30 )
         and cs_catalog_page_sk = cp_catalog_page_sk
        and cs_item_sk = i_item_sk
        and i_current_price > 50
@@ -57,7 +56,7 @@ group by cp_catalog_page_id)
      promotion
  where ws_sold_date_sk = d_date_sk
        and d_date between cast('1998-08-04' as date)
-                  and (cast('1998-09-04' as date))
+                  and (cast('1998-08-04' as date) + 30 )
         and ws_web_site_sk = web_site_sk
        and ws_item_sk = i_item_sk
        and i_current_price > 50

--- a/TPC-DS/templates/query-82.sql
+++ b/TPC-DS/templates/query-82.sql
@@ -8,7 +8,7 @@ select top 100 i_item_id
  where i_current_price between 30 and 30+30
  and inv_item_sk = i_item_sk
  and d_date_sk=inv_date_sk
- and d_date between cast('2002-05-30' as date) and (cast('2002-05-30' as date) +  60)
+ and d_date between cast('2002-05-30' as date) and (cast('2002-05-30' as date) +  60 )
  and i_manufact_id in (437,129,727,663)
  and inv_quantity_on_hand between 100 and 500
  and ss_item_sk = i_item_sk

--- a/TPC-DS/templates/query-92.sql
+++ b/TPC-DS/templates/query-92.sql
@@ -11,8 +11,7 @@ where
 i_manufact_id = 269
 and i_item_sk = ws_item_sk 
 and d_date between '1998-03-18' and 
---        (cast('1998-03-18' as date) + 90 days)
-		(cast('1998-09-18' as date))
+       (cast('1998-03-18' as date) + 90 )
 and d_date_sk = ws_sold_date_sk 
 and ws_ext_discount_amt  
      > ( 
@@ -24,8 +23,7 @@ and ws_ext_discount_amt
          WHERE 
               ws_item_sk = i_item_sk 
           and d_date between '1998-03-18' and
---                             (cast('1998-03-18' as date) + 90 days)
-			(cast('1998-09-18' as date))
+                        (cast('1998-03-18' as date) + 90 )
           and d_date_sk = ws_sold_date_sk 
       ) 
 order by sum(ws_ext_discount_amt)

--- a/TPC-DS/templates/query-94.sql
+++ b/TPC-DS/templates/query-94.sql
@@ -12,7 +12,7 @@ from
   ,web_site
 where
     d_date between '1999-5-01' and 
-           (cast('1999-5-01' as date) + 60)
+           (cast('1999-5-01' as date) + 60 )
 and ws1.ws_ship_date_sk = d_date_sk
 and ws1.ws_ship_addr_sk = ca_address_sk
 and ca_state = 'TX'

--- a/TPC-DS/templates/query-98.sql
+++ b/TPC-DS/templates/query-98.sql
@@ -18,8 +18,7 @@ where
   	and i_category in ('Jewelry', 'Sports', 'Books')
   	and ss_sold_date_sk = d_date_sk
 	and d_date between cast('2001-01-12' as date) 
---				and (cast('2001-01-12' as date) + 30 days)
-			 and (cast('2001-02-12' as date))
+			and (cast('2001-01-12' as date) + 30 )
 group by 
 	i_item_id
         ,i_item_desc 


### PR DESCRIPTION
I've re-written all of these queries to use the intervals that the benchmark specified, which would help with actually implementing the benchmark. Hopefully nobody sees a functional issue.

I will re-test these overnight.