### PR TITLE
Using native full outer join for TPCDS q51 and 97

### DIFF
--- a/TPC-DS/templates/query-51.sql
+++ b/TPC-DS/templates/query-51.sql
@@ -33,20 +33,13 @@ from (select item_sk
          over (partition by item_sk order by d_date rows between unbounded preceding and current row) web_cumulative
      ,max(store_sales)
          over (partition by item_sk order by d_date rows between unbounded preceding and current row) store_cumulative
-     from (
-select case when web.item_sk is not null then web.item_sk else store.item_sk end item_sk
+     from (select case when web.item_sk is not null then web.item_sk else store.item_sk end item_sk
                  ,case when web.d_date is not null then web.d_date else store.d_date end d_date
                  ,web.cume_sales web_sales
                  ,store.cume_sales store_sales
-           from web_v1 web left outer join store_v1 store on (web.item_sk = store.item_sk and web.d_date = store.d_date)
-union all
-select case when web.item_sk is not null then web.item_sk else store.item_sk end item_sk
-                 ,case when web.d_date is not null then web.d_date else store.d_date end d_date
-                 ,web.cume_sales web_sales
-                 ,store.cume_sales store_sales
-           from store_v1 store left outer join web_v1 web on (web.item_sk = store.item_sk and web.d_date = store.d_date) where web.item_sk is null
-          )x
- )y
+           from web_v1 web full outer join store_v1 store on (web.item_sk = store.item_sk
+                                                          and web.d_date = store.d_date)
+          )x )y
 where web_cumulative > store_cumulative
 order by item_sk
         ,d_date

--- a/TPC-DS/templates/query-97.sql
+++ b/TPC-DS/templates/query-97.sql
@@ -18,14 +18,9 @@ where cs_sold_date_sk = d_date_sk
   and d_month_seq between 1212 and 1212 + 11
 group by cs_bill_customer_sk
         ,cs_item_sk)
-select top 100 sum(case when ssci_customer_sk is not null and csci_customer_sk is null then 1 else 0 end) store_only
-      ,sum(case when ssci_customer_sk is null and csci_customer_sk is not null then 1 else 0 end) catalog_only
-      ,sum(case when ssci_customer_sk is not null and csci_customer_sk is not null then 1 else 0 end) store_and_catalog
-from (
-  select ssci.customer_sk as ssci_customer_sk, ssci.item_sk as ssci_item_sk,csci.customer_sk as csci_customer_sk,csci.item_sk as csci_item_sk 
-  from ssci left outer join csci on (ssci.customer_sk=csci.customer_sk and ssci.item_sk = csci.item_sk) 
-  union all select ssci.customer_sk as ssci_customer_sk, ssci.item_sk as ssci_item_sk,csci.customer_sk as csci_customer_sk,csci.item_sk as csci_item_sk 
-  from ssci right outer join csci on (ssci.customer_sk=csci.customer_sk and ssci.item_sk = csci.item_sk)
-  where ssci.customer_sk is null and ssci.item_sk is null and (csci.customer_sk is not null or csci.item_sk is not null)
-) a;
+select top 100 sum(case when ssci.customer_sk is not null and csci.customer_sk is null then 1 else 0 end) store_only
+      ,sum(case when ssci.customer_sk is null and csci.customer_sk is not null then 1 else 0 end) catalog_only
+      ,sum(case when ssci.customer_sk is not null and csci.customer_sk is not null then 1 else 0 end) store_and_catalog
+from ssci full outer join csci on (ssci.customer_sk=csci.customer_sk
+                               and ssci.item_sk = csci.item_sk);
 

--- a/run-benchmark.sh
+++ b/run-benchmark.sh
@@ -216,7 +216,7 @@ QRY11="0.0001000000" # defaults to tpch1g
 debug checking scale $SCALE for bench $BENCH
 # check for only valid scales
 if [[ "$BENCH" == "TPCH"  && "$SCALE" != "1" && "$SCALE" != "10" && "$SCALE" != "100" && "$SCALE" != "1000"  && "$SCALE" != "10000" || \
-      "$BENCH" == "TPCDS" && "$SCALE" != "1" && "$SCALE" != "100" && "$SCALE" != "1000" || \
+      "$BENCH" == "TPCDS" && "$SCALE" != "1" && "$SCALE" != "10" && "$SCALE" != "100" && "$SCALE" != "1000" || \
       "$BENCH" == "TPCC"  && "$SCALE" != "1" || \
       "$BENCH" == "HTAP"  && "$SCALE" != "25" ]]; then
    echo "Error: scale of $SCALE is not (yet) supported for $BENCH!"


### PR DESCRIPTION
Reverting full outer join workaround
Allow scalefactor 10 for TPCDS